### PR TITLE
Add multi-arch Docker build (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   push:
     tags: ["v*"]
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   test:
@@ -29,41 +29,100 @@ jobs:
         working-directory: server
         run: go test -race -count=1 ./...
 
-  publish:
-    runs-on: ubuntu-latest
+  binaries:
     needs: test
-    permissions:
-      contents: write
-      packages: write
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            name: xpbx-linux-amd64
+          - goarch: arm64
+            name: xpbx-linux-arm64
+
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - uses: actions/setup-go@v5
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          go-version: "1.25"
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
+      - name: Install templ
+        run: go install github.com/a-h/templ/cmd/templ@latest
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+      - name: Generate templ files
+        working-directory: server
+        run: templ generate
+
+      - name: Build
+        working-directory: server
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=${{ matrix.goarch }} go build -o ${{ matrix.name }} ./cmd/xpbx
+
+      - uses: actions/upload-artifact@v4
         with:
-          context: ./server
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          name: ${{ matrix.name }}
+          path: server/${{ matrix.name }}
+
+  release:
+    needs: binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          files: artifacts/**/*
+
+  docker:
+    needs: binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare binaries for Docker
+        run: |
+          mkdir -p docker-bin/linux-amd64 docker-bin/linux-arm64
+          cp artifacts/xpbx-linux-amd64/xpbx-linux-amd64 docker-bin/linux-amd64/xpbx
+          cp artifacts/xpbx-linux-arm64/xpbx-linux-arm64 docker-bin/linux-arm64/xpbx
+          chmod +x docker-bin/linux-amd64/xpbx docker-bin/linux-arm64/xpbx
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.release
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,12 @@
+FROM alpine:3.20
+
+ARG TARGETARCH
+
+RUN apk add --no-cache ca-certificates
+
+WORKDIR /app
+COPY docker-bin/linux-${TARGETARCH}/xpbx .
+COPY server/static ./static
+
+EXPOSE 8080
+CMD ["./xpbx"]


### PR DESCRIPTION
## Summary
- Build native Go binaries per architecture in CI matrix (no QEMU compilation)
- Assemble multi-platform Docker image with pre-built binaries via `Dockerfile.release`
- Add `latest` tag and GitHub Release with binary artifacts

## Test plan
- [ ] Merge and tag v0.2.1
- [ ] Verify release workflow produces amd64 + arm64 binaries
- [ ] Verify `docker pull ghcr.io/x-phone/xpbx:latest` works on both architectures