### PR TITLE
Bundle Asterisk + xpbx into single Docker image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,12 +1,26 @@
-FROM alpine:3.20
+FROM andrius/asterisk:latest
 
 ARG TARGETARCH
 
-RUN apk add --no-cache ca-certificates
+# Install ca-certificates and curl (for sound downloads in entrypoint)
+RUN apk add --no-cache ca-certificates curl python3
 
+# Asterisk config
+COPY asterisk/config/ /etc/asterisk/
+COPY asterisk/scripts/entrypoint.sh /scripts/entrypoint.sh
+RUN chmod +x /scripts/entrypoint.sh
+
+# xpbx web server
 WORKDIR /app
 COPY docker-bin/linux-${TARGETARCH}/xpbx .
 COPY server/static ./static
 
-EXPOSE 8080
-CMD ["./xpbx"]
+# Shared data volume
+RUN mkdir -p /data
+
+EXPOSE 5060/udp 5060/tcp 8080 10000-10099/udp
+
+COPY entrypoint-all.sh /entrypoint-all.sh
+RUN chmod +x /entrypoint-all.sh
+
+ENTRYPOINT ["/entrypoint-all.sh"]

--- a/entrypoint-all.sh
+++ b/entrypoint-all.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# All-in-one entrypoint: starts Asterisk + xpbx web server
+set -e
+
+# Run the Asterisk entrypoint (generates configs, starts Asterisk in background)
+/scripts/entrypoint.sh -f &
+ASTERISK_PID=$!
+
+# Wait for Asterisk to be ready
+sleep 2
+
+# Start xpbx web server
+export XPBX_LISTEN_ADDR=:8080
+export XPBX_DB_PATH=/data/asterisk-realtime.db
+export ARI_HOST=localhost
+export ARI_PORT=8088
+export ARI_USER=xpbx
+export ARI_PASSWORD=secret
+export LOG_LEVEL=${LOG_LEVEL:-info}
+
+cd /app
+./xpbx &
+XPBX_PID=$!
+
+# Wait for either process to exit
+wait -n $ASTERISK_PID $XPBX_PID 2>/dev/null || true
+
+# If one dies, kill the other
+kill $ASTERISK_PID $XPBX_PID 2>/dev/null
+wait


### PR DESCRIPTION
## Summary
- All-in-one Dockerfile based on `andrius/asterisk` with xpbx web server bundled
- `entrypoint-all.sh` starts both Asterisk and xpbx web server
- Enables single `docker run` without compose or cloning the repo

```bash
docker run -d --name xpbx \
  -p 5060:5060/udp -p 5060:5060/tcp \
  -p 8080:8080 \
  -p 10000-10099:10000-10099/udp \
  -e EXTERNAL_IP=$(tailscale ip -4) \
  ghcr.io/x-phone/xpbx:latest
```

## Test plan
- [ ] Merge and tag v0.2.2
- [ ] `docker run` starts both Asterisk and web UI
- [ ] Extensions register and calls work
- [ ] Web UI accessible on :8080