### PR TITLE
Build release binaries for linux, darwin, and windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   push:
     tags: ["v*"]
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   test:
@@ -29,41 +29,90 @@ jobs:
         working-directory: server
         run: go test -race -count=1 ./...
 
-  publish:
-    runs-on: ubuntu-latest
+  binaries:
     needs: test
-    permissions:
-      contents: write
-      packages: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            name: xpbx-linux-amd64
+          - goos: linux
+            goarch: arm64
+            name: xpbx-linux-arm64
+          - goos: darwin
+            goarch: amd64
+            name: xpbx-darwin-amd64
+          - goos: darwin
+            goarch: arm64
+            name: xpbx-darwin-arm64
+          - goos: windows
+            goarch: amd64
+            name: xpbx-windows-amd64.exe
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - uses: actions/setup-go@v5
         with:
-          registry: ${{ env.REGISTRY }}
+          go-version: "1.25"
+
+      - name: Install templ
+        run: go install github.com/a-h/templ/cmd/templ@latest
+
+      - name: Generate templ files
+        working-directory: server
+        run: templ generate
+
+      - name: Build
+        working-directory: server
+        run: CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ${{ matrix.name }} ./cmd/xpbx
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: server/${{ matrix.name }}
+
+  release:
+    needs: binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/**/*
+
+  docker:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=raw,value=latest
 
-      - name: Build and push Docker image
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: ./server
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Cross-compile Go binaries for 5 targets and attach to GitHub releases:
  - `xpbx-linux-amd64`, `xpbx-linux-arm64`
  - `xpbx-darwin-amd64`, `xpbx-darwin-arm64`
  - `xpbx-windows-amd64.exe`
- Docker image stays linux/amd64 only (no QEMU)
- `binaries` and `docker` jobs run in parallel after tests pass
- Added `latest` tag to Docker image

## Test plan

- [x] Cross-compilation verified locally for linux/amd64, darwin/arm64, windows/amd64
- [ ] Tag a test release and verify all 5 binaries appear in the GitHub release
- [ ] Verify Docker image pushed with correct tags