### PR TITLE
Add all-in-one Docker image and multi-platform release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ./server
+          context: .
+          file: Dockerfile.release
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+## Project Overview
+
+xpbx is a Dockerized Asterisk PBX with a web management UI. It provides out-of-the-box extension, trunk, and dialplan management via a Go + HTMX web interface backed by SQLite Realtime.
+
+Part of the [x-phone](https://github.com/x-phone) ecosystem.
+
+## Repository Structure
+
+- **`asterisk/`** — Asterisk configuration files and entrypoint script
+- **`server/`** — Go web server (HTMX + templ + SQLite)
+  - `cmd/xpbx/` — Entry point
+  - `internal/ari/` — Asterisk REST Interface client
+  - `internal/config/` — Environment variable configuration
+  - `internal/database/` — SQLite layer (migrations, CRUD, cleanup)
+  - `internal/handlers/` — HTTP request handlers
+  - `internal/router/` — Route definitions + middleware
+  - `templates/` — templ HTML templates (layouts, pages, partials)
+  - `static/` — CSS
+- **`Dockerfile.release`** — All-in-one image (Asterisk + xpbx)
+- **`entrypoint-all.sh`** — All-in-one container entrypoint
+- **`docker-compose.yml`** — Two-container dev setup
+
+## Build & Run
+
+```bash
+make up          # Start Asterisk + xpbx web UI
+make down        # Stop everything
+make logs        # Follow logs
+make asterisk-cli  # Open Asterisk console
+make sip-status    # Show SIP endpoint registrations
+```
+
+### Server development (inside server/)
+
+```bash
+cd server
+make generate    # Generate templ files
+make build       # Build binary
+make run         # Run locally
+```
+
+## Architecture
+
+- **Asterisk** runs with PJSIP Realtime backed by SQLite (`/data/asterisk-realtime.db`)
+- **xpbx server** manages the same SQLite file (CRUD for extensions, trunks, dialplan)
+- Communication with Asterisk is via **ARI** (HTTP REST on port 8088)
+- **No external database** — SQLite with WAL mode handles concurrent access
+- **Docker image** (`ghcr.io/x-phone/xpbx`) bundles both Asterisk + xpbx in a single container
+- **docker-compose.yml** runs them as separate containers for development
+
+## Key Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `XPBX_LISTEN_ADDR` | `:8080` | Web UI listen address |
+| `XPBX_DB_PATH` | `/data/asterisk-realtime.db` | SQLite database path |
+| `ARI_HOST` | `asterisk` | Asterisk hostname |
+| `ARI_PORT` | `8088` | ARI port |
+| `ARI_USER` | `xpbx` | ARI auth user |
+| `ARI_PASSWORD` | `secret` | ARI auth password |
+| `EXTERNAL_IP` | auto-detected | Host IP for SIP NAT |
+| `SIP_PORT` | `5060` | Asterisk SIP port |
+| `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+| `VOICEWORKER_HOST` | _(empty/disabled)_ | When set, creates voiceworker trunk at this host:port |
+| `VOICEWORKER_EXTEN` | `2000` | Extension number that routes to voiceworker trunk |
+
+## Conventions
+
+- Never add `Co-Authored-By` lines to commit messages
+- Go logging uses `logrus`
+- Templates use `templ` (compile-time HTML generation)
+- Frontend uses HTMX for interactivity + Tailwind CSS (CDN) for styling
+- SQLite uses pure Go driver (`modernc.org/sqlite`) — no CGO required

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,41 @@
+# All-in-one xpbx image: Asterisk PBX + web management UI
+# Built on top of andrius/asterisk (Debian, compiled from source)
+
+FROM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache git
+RUN go install github.com/a-h/templ/cmd/templ@latest
+
+WORKDIR /app
+COPY server/go.mod server/go.sum ./
+RUN go mod download
+
+COPY server/ .
+RUN templ generate
+RUN CGO_ENABLED=0 GOOS=linux go build -o xpbx ./cmd/xpbx
+
+# --- Production image ---
+FROM andrius/asterisk:latest
+
+USER root
+
+# Asterisk config
+COPY asterisk/config/ /etc/asterisk/
+COPY asterisk/scripts/entrypoint.sh /scripts/entrypoint.sh
+
+# xpbx web server
+COPY --from=builder /app/xpbx /app/xpbx
+COPY --from=builder /app/static /app/static
+
+# All-in-one entrypoint
+COPY entrypoint-all.sh /entrypoint-all.sh
+RUN chmod +x /entrypoint-all.sh /scripts/entrypoint.sh
+
+# Data directory (SQLite DB, sounds)
+RUN mkdir -p /data && chown -R asterisk:asterisk /data /app /etc/asterisk
+
+USER asterisk
+
+EXPOSE 5060/udp 5060/tcp 8080 10000-10099/udp
+
+ENTRYPOINT ["/entrypoint-all.sh"]

--- a/README.md
+++ b/README.md
@@ -17,15 +17,29 @@ Self-hosted PBX with a web UI. Manages Asterisk via SQLite Realtime and ARI.
 
 ## Quick start
 
+### Docker
+
+```bash
+docker run -d --name xpbx \
+  -p 5060:5060/udp -p 5060:5060/tcp \
+  -p 8080:8080 \
+  -p 10000-10099:10000-10099/udp \
+  ghcr.io/x-phone/xpbx:latest
+```
+
+### Docker Compose (for development)
+
 ```bash
 git clone https://github.com/x-phone/xpbx.git
 cd xpbx
 make up
 ```
 
+---
+
 Open **http://localhost:8080** — the web UI is ready.
 
-Register a SIP phone (Obi200, Obi2182, Linphone, Obi100, etc.) to `your-ip:5060` with one of the seeded extensions (1001/1002/1003, password: `password123`).
+Register a SIP phone (Zoiper, Linphone, Obi200, etc.) to `your-ip:5060` with one of the seeded extensions (1001/1002/1003, password: `password123`).
 
 A sample SIP trunk (`my-provider` → `sip.example.com`) and outbound route (`9 + 10 digits`) are also seeded — edit them in the UI with your real provider details.
 
@@ -36,36 +50,72 @@ A sample SIP trunk (`my-provider` → `sip.example.com`) and outbound route (`9 
 Override for specific network setups:
 
 ```bash
-# Tailscale / VPN
-EXTERNAL_IP=100.96.49.117 make up
+# Docker
+docker run -d --name xpbx \
+  -p 5060:5060/udp -p 5060:5060/tcp \
+  -p 8080:8080 \
+  -p 10000-10099:10000-10099/udp \
+  -e EXTERNAL_IP=192.168.1.50 \
+  ghcr.io/x-phone/xpbx:latest
 
-# LAN-only
-EXTERNAL_IP=192.168.1.50 make up
+# Docker Compose
+EXTERNAL_IP=100.96.49.117 make up
 ```
 
-Or set it in a `.env` file:
+Or set it in a `.env` file (docker-compose only):
 
 ```
 EXTERNAL_IP=100.96.49.117
 ```
 
+### Asterisk CLI
+
+Access the Asterisk console for debugging:
+
+```bash
+# Docker
+docker exec -it xpbx asterisk -rvvv
+
+# Docker Compose
+make asterisk-cli
+```
+
+### Data persistence
+
+To persist data across container restarts, mount a volume:
+
+```bash
+docker run -d --name xpbx \
+  -v xpbx-data:/data \
+  -p 5060:5060/udp -p 5060:5060/tcp \
+  -p 8080:8080 \
+  -p 10000-10099:10000-10099/udp \
+  ghcr.io/x-phone/xpbx:latest
+```
+
 ## Architecture
 
 ```
-┌──────────────┐     SQLite      ┌──────────────┐
-│   xpbx       │───(Realtime)───▸│   Asterisk   │
-│   Web UI     │                 │   PBX        │
-│   Go/templ   │◂───(ARI)───────│   pjsip      │
-└──────┬───────┘                 └──────┬───────┘
-       │ :8080                          │ :5060
-       │                                │
-   Browser                         SIP Phones
+┌─────────────────────────────────┐
+│         xpbx container          │
+│                                 │
+│  ┌──────────┐    ┌───────────┐  │
+│  │  xpbx    │───▸│ Asterisk  │  │
+│  │  Web UI  │    │ PBX       │  │
+│  │  Go/templ│◂───│ pjsip     │  │
+│  └────┬─────┘    └─────┬─────┘  │
+│       │ :8080          │ :5060  │
+│       │    SQLite ◂──▸ │        │
+└───────┼────────────────┼────────┘
+        │                │
+    Browser          SIP Phones
 ```
 
 - **xpbx** writes SIP configuration and dialplan rules to a shared SQLite database
 - **Asterisk** reads them via [Realtime](https://docs.asterisk.org/Configuration/Interfaces/Asterisk-Realtime-Architecture/) (`res_config_sqlite3`)
 - **ARI** (Asterisk REST Interface) provides live system info, channel management, and module control
 - Changes take effect immediately — xpbx checkpoints the WAL and reloads the SQLite module
+- The Docker image bundles both services; `docker-compose.yml` runs them as separate containers for development
 
 ## Services
 
@@ -78,7 +128,7 @@ EXTERNAL_IP=100.96.49.117
 
 ## Configuration
 
-All configuration is via environment variables in `docker-compose.yml`:
+All configuration is via environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -97,6 +147,16 @@ All configuration is via environment variables in `docker-compose.yml`:
 ### Asterisk config overrides
 
 The default Asterisk configuration works out of the box. For advanced use cases, you can override any config file via volume mounts:
+
+```bash
+# Docker
+docker run -d --name xpbx \
+  -v ./my-pjsip.conf:/etc/asterisk/pjsip.conf:ro \
+  -p 5060:5060/udp -p 5060:5060/tcp \
+  -p 8080:8080 \
+  -p 10000-10099:10000-10099/udp \
+  ghcr.io/x-phone/xpbx:latest
+```
 
 ```yaml
 # docker-compose.override.yml
@@ -157,8 +217,10 @@ xpbx/
 │   │   └── router/       # Routes and middleware
 │   ├── templates/        # templ HTML templates
 │   ├── static/           # CSS and JS assets
-│   └── Dockerfile
-├── docker-compose.yml
+│   └── Dockerfile        # Server-only image (for docker-compose)
+├── Dockerfile.release    # All-in-one image (Asterisk + xpbx)
+├── entrypoint-all.sh     # All-in-one entrypoint
+├── docker-compose.yml    # Two-container dev setup
 └── Makefile
 ```
 
@@ -306,9 +368,20 @@ xpbx is the PBX component of the [x-phone](https://github.com/x-phone) ecosystem
 
 ### xbridge integration
 
-To connect xpbx to [xbridge](https://github.com/x-phone/xbridge) for voice AI, set `VOICEWORKER_HOST` in your `.env` or `docker-compose.yml`:
+To connect xpbx to [xbridge](https://github.com/x-phone/xbridge) for voice AI, set `VOICEWORKER_HOST`:
+
+```bash
+# Docker
+docker run -d --name xpbx \
+  -p 5060:5060/udp -p 5060:5060/tcp \
+  -p 8080:8080 \
+  -p 10000-10099:10000-10099/udp \
+  -e VOICEWORKER_HOST=xbridge:5080 \
+  ghcr.io/x-phone/xpbx:latest
+```
 
 ```yaml
+# docker-compose.yml
 environment:
   - VOICEWORKER_HOST=xbridge:5080
   - VOICEWORKER_EXTEN=2000        # optional, default is 2000

--- a/asterisk/config/modules.conf
+++ b/asterisk/config/modules.conf
@@ -62,3 +62,5 @@ noload => chan_iax2.so
 noload => chan_sip.so
 noload => res_pjsip_transport_websocket.so
 noload => res_timing_pthread.so
+noload => chan_alsa.so
+noload => chan_oss.so

--- a/entrypoint-all.sh
+++ b/entrypoint-all.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# All-in-one entrypoint: Asterisk + xpbx web server
+set -e
+
+# --- Generate Asterisk configs (NAT, transport, voiceworker) ---
+# Reuse the same config generation logic from the Asterisk entrypoint.
+# Source it as a function library — we override exec to prevent it from launching Asterisk.
+exec() { :; }
+. /scripts/entrypoint.sh
+unset -f exec
+
+# --- Start Asterisk ---
+# Redirect stdout to suppress NUL byte flood when running without a TTY.
+# Asterisk logs go through logger.conf (syslog/files), not stdout.
+/usr/sbin/asterisk -fp > /dev/null 2>&1 &
+ASTERISK_PID=$!
+
+# Wait for Asterisk to be ready
+for i in $(seq 1 30); do
+  /usr/sbin/asterisk -rx "core show version" > /dev/null 2>&1 && break
+  sleep 1
+done
+
+# --- Start xpbx web server ---
+export XPBX_LISTEN_ADDR=${XPBX_LISTEN_ADDR:-:8080}
+export XPBX_DB_PATH=${XPBX_DB_PATH:-/data/asterisk-realtime.db}
+export ARI_HOST=localhost
+export ARI_PORT=8088
+export ARI_USER=${ARI_USER:-xpbx}
+export ARI_PASSWORD=${ARI_PASSWORD:-secret}
+export LOG_LEVEL=${LOG_LEVEL:-info}
+
+/app/xpbx &
+XPBX_PID=$!
+
+# Reload PJSIP after xpbx seeds the database
+sleep 2
+/usr/sbin/asterisk -rx "module reload res_pjsip.so" > /dev/null 2>&1 || true
+
+echo "xpbx ready — SIP on :5060, Web UI on :8080"
+
+# Shutdown handler
+trap 'kill $ASTERISK_PID $XPBX_PID 2>/dev/null; wait' TERM INT
+
+# Wait for either process to exit, then stop the other
+wait -n $ASTERISK_PID $XPBX_PID 2>/dev/null || true
+kill $ASTERISK_PID $XPBX_PID 2>/dev/null || true
+wait 2>/dev/null || true
+exit 1


### PR DESCRIPTION
## Summary

- **All-in-one Docker image** — bundles Asterisk + xpbx in a single container (`Dockerfile.release` on top of `andrius/asterisk:latest`)
- **Multi-platform binaries** — cross-compiled for linux/darwin (amd64+arm64) and windows (amd64), attached to GitHub releases
- **CI pipeline** — tests, builds 5 binaries, publishes Docker image to GHCR, creates GitHub release — all in parallel
- **noload chan_alsa/chan_oss** — suppresses ALSA/JACK noise in containers
- **README** — docker run quick start, Asterisk CLI access, data persistence, updated architecture diagram

## Tested locally

- Built `Dockerfile.release` on Apple Silicon Mac
- Ran container: Asterisk + xpbx both start, clean logs, no ALSA/NUL noise
- Verified: `asterisk -rvvv` CLI, all 4 PJSIP endpoints loaded, web UI HTTP 200
- Cross-compilation verified for linux/amd64, darwin/arm64, windows/amd64

## Test plan

- [ ] Merge and tag `v0.2.1`
- [ ] Verify CI: 5 binaries in GitHub release, Docker image pushed to GHCR
- [ ] `docker run ghcr.io/x-phone/xpbx:0.2.1` — web UI + SIP working
- [ ] `docker exec -it xpbx asterisk -rvvv` — CLI access works