### PR TITLE
Add JSON REST API for trunks and dialplan

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,129 +224,79 @@ xpbx/
 
 ## API Reference
 
-xpbx exposes a web UI and a set of HTTP endpoints for managing extensions, trunks, and dialplan rules. Most endpoints return HTML (designed for HTMX), but can be called from any HTTP client.
+xpbx exposes two sets of endpoints:
 
-All write operations use **form-encoded** request bodies (`application/x-www-form-urlencoded`).
+- **JSON API** (`/api/...`) — for programmatic automation. Accepts and returns `application/json`.
+- **HTML endpoints** — for the web UI (HTMX). Accept `application/x-www-form-urlencoded`, return HTML.
 
-### Extensions
+### JSON API — Trunks
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/extensions` | List all extensions |
-| `GET` | `/extensions/new` | New extension form |
-| `GET` | `/extensions/{id}/edit` | Edit extension form |
-| `POST` | `/extensions` | Create extension |
-| `PUT` | `/extensions/{id}` | Update extension |
-| `DELETE` | `/extensions/{id}` | Delete extension |
-
-**Create / Update fields:**
-
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `extension` | yes | — | Extension number (e.g. `1001`) |
-| `password` | yes | — | SIP auth password |
-| `context` | yes | `from-internal` | Dialplan context |
-| `display_name` | no | — | Friendly name |
-| `codecs` | no | `ulaw` | Comma-separated codec list |
-| `max_contacts` | no | `10` | Max simultaneous registrations |
-| `routing_enabled` | no | `on` | Enable call routing rules |
-| `routing_pattern` | no | `ring_voicemail` | One of: `ring_only`, `ring_voicemail`, `voicemail_only` |
-| `routing_timeout` | no | `20` | Ring timeout in seconds |
-| `vm_enabled` | no | `on` | Enable voicemail |
-| `vm_pin` | no | `0000` | Voicemail access PIN |
-| `vm_email` | no | — | Email for voicemail notifications |
-
-**Example — create an extension:**
+| `GET` | `/api/trunks` | List all trunks |
+| `GET` | `/api/trunks/{id}` | Get single trunk |
+| `POST` | `/api/trunks` | Create trunk |
+| `PUT` | `/api/trunks/{id}` | Update trunk |
+| `DELETE` | `/api/trunks/{id}` | Delete trunk |
 
 ```bash
-curl -X POST http://localhost:8080/extensions \
-  -d "extension=1004&password=secret4&context=from-internal&display_name=Office+Phone&codecs=ulaw,g722"
+# List trunks
+curl http://localhost:8080/api/trunks
+
+# Create a trunk
+curl -X POST http://localhost:8080/api/trunks \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-trunk","host":"sip.provider.com","port":5060,"context":"from-trunk","codecs":"ulaw","auth_user":"myuser","auth_pass":"mypass"}'
+
+# Update a trunk
+curl -X PUT http://localhost:8080/api/trunks/1 \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-trunk","host":"sip2.provider.com","port":5060,"context":"from-trunk"}'
+
+# Delete a trunk
+curl -X DELETE http://localhost:8080/api/trunks/1
 ```
 
-### Trunks
+### JSON API — Dialplan
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/trunks` | List all trunks |
-| `GET` | `/trunks/new` | New trunk form |
-| `GET` | `/trunks/{id}/edit` | Edit trunk form |
-| `POST` | `/trunks` | Create trunk |
-| `PUT` | `/trunks/{id}` | Update trunk |
-| `DELETE` | `/trunks/{id}` | Delete trunk |
-
-**Create / Update fields:**
-
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `name` | yes | — | Trunk identifier (unique) |
-| `host` | yes | — | SIP server hostname or IP |
-| `context` | yes | `from-trunk` | Dialplan context for inbound calls |
-| `display_name` | no | — | Friendly name |
-| `provider` | no | — | Provider name (informational) |
-| `port` | no | `5060` | SIP port |
-| `auth_user` | no | — | SIP authentication username |
-| `auth_pass` | no | — | SIP authentication password |
-| `codecs` | no | `ulaw` | Comma-separated codec list |
-
-**Example — create a trunk:**
+| `GET` | `/api/dialplan` | List all rules |
+| `GET` | `/api/dialplan/{id}` | Get single rule |
+| `POST` | `/api/dialplan` | Create rule |
+| `PUT` | `/api/dialplan/{id}` | Update rule |
+| `DELETE` | `/api/dialplan/{id}` | Delete rule |
 
 ```bash
-curl -X POST http://localhost:8080/trunks \
-  -d "name=my-provider&host=sip.provider.com&context=from-trunk&auth_user=myuser&auth_pass=mypass"
+# List dialplan rules
+curl http://localhost:8080/api/dialplan
+
+# Create a dialplan rule
+curl -X POST http://localhost:8080/api/dialplan \
+  -H "Content-Type: application/json" \
+  -d '{"context":"from-internal","exten":"_3XXX","priority":1,"app":"Dial","appdata":"PJSIP/${EXTEN}@my-trunk,30"}'
+
+# Delete a rule
+curl -X DELETE http://localhost:8080/api/dialplan/10
 ```
 
-### Dialplan
+### JSON API — System
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/dialplan` | List rules (simple view) |
-| `GET` | `/dialplan?mode=advanced` | List rules (raw table view) |
-| `GET` | `/dialplan/new` | New rule form |
-| `GET` | `/dialplan/{id}/edit` | Edit rule form |
-| `POST` | `/dialplan` | Create rule |
-| `PUT` | `/dialplan/{id}` | Update rule |
-| `DELETE` | `/dialplan/{id}` | Delete rule |
-
-**Create / Update fields:**
-
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `context` | yes | `from-internal` | Dialplan context |
-| `exten` | yes | — | Extension pattern (e.g. `1001`, `_2XXX`, `_NXXXXXX`) |
-| `priority` | yes | `1` | Execution order |
-| `app` | yes | — | Asterisk application (`Dial`, `VoiceMail`, `Hangup`, etc.) |
-| `appdata` | no | — | Application arguments (e.g. `PJSIP/1001,20`) |
-
-**Example — create a dialplan rule:**
-
-```bash
-curl -X POST http://localhost:8080/dialplan \
-  -d "context=from-internal&exten=_9NXXXXXX&priority=1&app=Dial&appdata=PJSIP/my-provider/\${EXTEN:1}"
-```
-
-### Dashboard & System
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/dashboard` | Dashboard page |
-| `GET` | `/partials/system-info` | Asterisk system info (HTML partial, polled every 10s) |
-| `GET` | `/partials/registrations` | Registered SIP endpoints (HTML partial, polled every 5s) |
-| `GET` | `/partials/active-calls` | Active call channels (HTML partial, polled every 5s) |
-| `GET` | `/partials/sip-config/{id}` | SIP configuration modal for extension |
 | `DELETE` | `/api/calls/{channelId}` | Hang up an active call |
 | `POST` | `/api/asterisk/reload` | Reload Asterisk PJSIP module |
 
-**Example — hang up a call:**
+### HTML Endpoints (Web UI)
 
-```bash
-curl -X DELETE http://localhost:8080/api/calls/1234567890.42
-```
+The web UI uses form-encoded HTML endpoints. These can also be called programmatically but the JSON API above is preferred for automation.
 
-**Example — reload PJSIP:**
-
-```bash
-curl -X POST http://localhost:8080/api/asterisk/reload
-```
+| Resource | List | Create | Update | Delete |
+|----------|------|--------|--------|--------|
+| Extensions | `GET /extensions` | `POST /extensions` | `PUT /extensions/{id}` | `DELETE /extensions/{id}` |
+| Trunks | `GET /trunks` | `POST /trunks` | `PUT /trunks/{id}` | `DELETE /trunks/{id}` |
+| Dialplan | `GET /dialplan` | `POST /dialplan` | `PUT /dialplan/{id}` | `DELETE /dialplan/{id}` |
+| Dashboard | `GET /dashboard` | — | — | — |
 
 ## Part of x-phone
 

--- a/server/internal/handlers/api.go
+++ b/server/internal/handlers/api.go
@@ -1,0 +1,254 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/x-phone/xpbx/server/internal/ari"
+	"github.com/x-phone/xpbx/server/internal/database"
+)
+
+type APIHandler struct {
+	db  *database.DB
+	ari *ari.Client
+}
+
+func NewAPIHandler(db *database.DB, ariClient *ari.Client) *APIHandler {
+	return &APIHandler{db: db, ari: ariClient}
+}
+
+func (h *APIHandler) notifyAsterisk() {
+	h.db.Checkpoint()
+	if err := h.ari.RestartModule("res_config_sqlite3.so"); err != nil {
+		log.WithError(err).Warn("Failed to reload Asterisk SQLite module")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// --- Trunks ---
+
+func (h *APIHandler) ListTrunks(w http.ResponseWriter, r *http.Request) {
+	trunks, err := h.db.ListTrunks()
+	if err != nil {
+		log.WithError(err).Error("API: failed to list trunks")
+		writeError(w, http.StatusInternalServerError, "failed to list trunks")
+		return
+	}
+	if trunks == nil {
+		trunks = []database.Trunk{}
+	}
+	writeJSON(w, http.StatusOK, trunks)
+}
+
+func (h *APIHandler) GetTrunk(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid trunk ID")
+		return
+	}
+	t, err := h.db.GetTrunk(id)
+	if err != nil {
+		log.WithError(err).Error("API: failed to get trunk")
+		writeError(w, http.StatusInternalServerError, "failed to get trunk")
+		return
+	}
+	if t == nil {
+		writeError(w, http.StatusNotFound, "trunk not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, t)
+}
+
+func (h *APIHandler) CreateTrunk(w http.ResponseWriter, r *http.Request) {
+	var t database.Trunk
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if t.Name == "" || t.Host == "" || t.Context == "" {
+		writeError(w, http.StatusBadRequest, "name, host, and context are required")
+		return
+	}
+	if t.Port == 0 {
+		t.Port = 5060
+	}
+	if t.Codecs == "" {
+		t.Codecs = "ulaw"
+	}
+	t.Transport = "transport-udp"
+
+	if err := h.db.CreateTrunk(&t); err != nil {
+		log.WithError(err).Error("API: failed to create trunk")
+		writeError(w, http.StatusInternalServerError, "failed to create trunk: "+err.Error())
+		return
+	}
+
+	h.notifyAsterisk()
+	log.WithField("trunk", t.Name).Info("API: trunk created")
+	writeJSON(w, http.StatusCreated, t)
+}
+
+func (h *APIHandler) UpdateTrunk(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid trunk ID")
+		return
+	}
+
+	var t database.Trunk
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	t.ID = id
+	if t.Codecs == "" {
+		t.Codecs = "ulaw"
+	}
+	t.Transport = "transport-udp"
+
+	if err := h.db.UpdateTrunk(&t); err != nil {
+		log.WithError(err).Error("API: failed to update trunk")
+		writeError(w, http.StatusInternalServerError, "failed to update trunk")
+		return
+	}
+
+	h.notifyAsterisk()
+	log.WithField("trunk", t.Name).Info("API: trunk updated")
+	writeJSON(w, http.StatusOK, t)
+}
+
+func (h *APIHandler) DeleteTrunk(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid trunk ID")
+		return
+	}
+	if err := h.db.DeleteTrunk(id); err != nil {
+		log.WithError(err).Error("API: failed to delete trunk")
+		writeError(w, http.StatusInternalServerError, "failed to delete trunk")
+		return
+	}
+
+	h.notifyAsterisk()
+	log.WithField("trunk_id", id).Info("API: trunk deleted")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Dialplan ---
+
+func (h *APIHandler) ListDialplanRules(w http.ResponseWriter, r *http.Request) {
+	rules, err := h.db.ListDialplanRules()
+	if err != nil {
+		log.WithError(err).Error("API: failed to list dialplan rules")
+		writeError(w, http.StatusInternalServerError, "failed to list dialplan rules")
+		return
+	}
+	if rules == nil {
+		rules = []database.DialplanRule{}
+	}
+	writeJSON(w, http.StatusOK, rules)
+}
+
+func (h *APIHandler) GetDialplanRule(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid rule ID")
+		return
+	}
+	rule, err := h.db.GetDialplanRule(id)
+	if err != nil {
+		log.WithError(err).Error("API: failed to get dialplan rule")
+		writeError(w, http.StatusInternalServerError, "failed to get dialplan rule")
+		return
+	}
+	if rule == nil {
+		writeError(w, http.StatusNotFound, "rule not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, rule)
+}
+
+func (h *APIHandler) CreateDialplanRule(w http.ResponseWriter, r *http.Request) {
+	var rule database.DialplanRule
+	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	if rule.Context == "" || rule.Exten == "" || rule.App == "" {
+		writeError(w, http.StatusBadRequest, "context, exten, and app are required")
+		return
+	}
+	if rule.Priority == 0 {
+		rule.Priority = 1
+	}
+
+	if err := h.db.CreateDialplanRule(&rule); err != nil {
+		log.WithError(err).Error("API: failed to create dialplan rule")
+		writeError(w, http.StatusInternalServerError, "failed to create rule: "+err.Error())
+		return
+	}
+
+	h.notifyAsterisk()
+	log.WithFields(log.Fields{"context": rule.Context, "exten": rule.Exten}).Info("API: dialplan rule created")
+	writeJSON(w, http.StatusCreated, rule)
+}
+
+func (h *APIHandler) UpdateDialplanRule(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid rule ID")
+		return
+	}
+
+	var rule database.DialplanRule
+	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	rule.ID = id
+	if rule.Priority == 0 {
+		rule.Priority = 1
+	}
+
+	if err := h.db.UpdateDialplanRule(&rule); err != nil {
+		log.WithError(err).Error("API: failed to update dialplan rule")
+		writeError(w, http.StatusInternalServerError, "failed to update rule")
+		return
+	}
+
+	h.notifyAsterisk()
+	log.WithField("id", id).Info("API: dialplan rule updated")
+	writeJSON(w, http.StatusOK, rule)
+}
+
+func (h *APIHandler) DeleteDialplanRule(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid rule ID")
+		return
+	}
+	if err := h.db.DeleteDialplanRule(id); err != nil {
+		log.WithError(err).Error("API: failed to delete dialplan rule")
+		writeError(w, http.StatusInternalServerError, "failed to delete rule")
+		return
+	}
+
+	h.notifyAsterisk()
+	log.WithField("id", id).Info("API: dialplan rule deleted")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/internal/handlers/api.go
+++ b/server/internal/handlers/api.go
@@ -12,6 +12,8 @@ import (
 	"github.com/x-phone/xpbx/server/internal/database"
 )
 
+const maxRequestBody = 1 << 20 // 1 MB
+
 type APIHandler struct {
 	db  *database.DB
 	ari *ari.Client
@@ -38,6 +40,11 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 
+// sanitizeTrunk clears sensitive fields before sending a trunk in a response.
+func sanitizeTrunk(t *database.Trunk) {
+	t.AuthPass = ""
+}
+
 // --- Trunks ---
 
 func (h *APIHandler) ListTrunks(w http.ResponseWriter, r *http.Request) {
@@ -49,6 +56,9 @@ func (h *APIHandler) ListTrunks(w http.ResponseWriter, r *http.Request) {
 	}
 	if trunks == nil {
 		trunks = []database.Trunk{}
+	}
+	for i := range trunks {
+		sanitizeTrunk(&trunks[i])
 	}
 	writeJSON(w, http.StatusOK, trunks)
 }
@@ -69,10 +79,12 @@ func (h *APIHandler) GetTrunk(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "trunk not found")
 		return
 	}
+	sanitizeTrunk(t)
 	writeJSON(w, http.StatusOK, t)
 }
 
 func (h *APIHandler) CreateTrunk(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 	var t database.Trunk
 	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
@@ -93,12 +105,13 @@ func (h *APIHandler) CreateTrunk(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.db.CreateTrunk(&t); err != nil {
 		log.WithError(err).Error("API: failed to create trunk")
-		writeError(w, http.StatusInternalServerError, "failed to create trunk: "+err.Error())
+		writeError(w, http.StatusInternalServerError, "failed to create trunk")
 		return
 	}
 
 	h.notifyAsterisk()
 	log.WithField("trunk", t.Name).Info("API: trunk created")
+	sanitizeTrunk(&t)
 	writeJSON(w, http.StatusCreated, t)
 }
 
@@ -109,6 +122,7 @@ func (h *APIHandler) UpdateTrunk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 	var t database.Trunk
 	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
@@ -128,6 +142,7 @@ func (h *APIHandler) UpdateTrunk(w http.ResponseWriter, r *http.Request) {
 
 	h.notifyAsterisk()
 	log.WithField("trunk", t.Name).Info("API: trunk updated")
+	sanitizeTrunk(&t)
 	writeJSON(w, http.StatusOK, t)
 }
 
@@ -183,6 +198,7 @@ func (h *APIHandler) GetDialplanRule(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *APIHandler) CreateDialplanRule(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 	var rule database.DialplanRule
 	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
@@ -199,7 +215,7 @@ func (h *APIHandler) CreateDialplanRule(w http.ResponseWriter, r *http.Request) 
 
 	if err := h.db.CreateDialplanRule(&rule); err != nil {
 		log.WithError(err).Error("API: failed to create dialplan rule")
-		writeError(w, http.StatusInternalServerError, "failed to create rule: "+err.Error())
+		writeError(w, http.StatusInternalServerError, "failed to create rule")
 		return
 	}
 
@@ -215,6 +231,7 @@ func (h *APIHandler) UpdateDialplanRule(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 	var rule database.DialplanRule
 	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")

--- a/server/internal/handlers/api_test.go
+++ b/server/internal/handlers/api_test.go
@@ -1,0 +1,256 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/x-phone/xpbx/server/internal/ari"
+	"github.com/x-phone/xpbx/server/internal/database"
+)
+
+func setupAPI(t *testing.T) (*APIHandler, *database.DB) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := database.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ariClient := ari.NewClient("http://localhost:8088", "user", "pass")
+	return NewAPIHandler(db, ariClient), db
+}
+
+func doRequest(handler http.HandlerFunc, method, path string, body any, vars map[string]string) *httptest.ResponseRecorder {
+	var reqBody *bytes.Buffer
+	if body != nil {
+		b, _ := json.Marshal(body)
+		reqBody = bytes.NewBuffer(b)
+	} else {
+		reqBody = &bytes.Buffer{}
+	}
+	req := httptest.NewRequest(method, path, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	if vars != nil {
+		req = mux.SetURLVars(req, vars)
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+// --- Trunk API tests ---
+
+func TestAPITrunks_CRUD(t *testing.T) {
+	h, _ := setupAPI(t)
+
+	// List — empty
+	w := doRequest(h.ListTrunks, "GET", "/api/trunks", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: got %d, want 200", w.Code)
+	}
+	var trunks []database.Trunk
+	json.NewDecoder(w.Body).Decode(&trunks)
+	if len(trunks) != 0 {
+		t.Fatalf("list: got %d trunks, want 0", len(trunks))
+	}
+
+	// Create
+	trunk := map[string]any{
+		"name":    "test-trunk",
+		"host":    "10.0.0.1",
+		"port":    5080,
+		"context": "from-trunk",
+		"codecs":  "ulaw,alaw",
+	}
+	w = doRequest(h.CreateTrunk, "POST", "/api/trunks", trunk, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: got %d, want 201. body: %s", w.Code, w.Body.String())
+	}
+	var created database.Trunk
+	json.NewDecoder(w.Body).Decode(&created)
+	if created.Name != "test-trunk" {
+		t.Errorf("create: name = %q, want %q", created.Name, "test-trunk")
+	}
+	if created.ID == 0 {
+		t.Error("create: ID should be set")
+	}
+
+	// Get
+	w = doRequest(h.GetTrunk, "GET", "/api/trunks/1", nil, map[string]string{"id": "1"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: got %d, want 200", w.Code)
+	}
+	var got database.Trunk
+	json.NewDecoder(w.Body).Decode(&got)
+	if got.Host != "10.0.0.1" {
+		t.Errorf("get: host = %q, want %q", got.Host, "10.0.0.1")
+	}
+
+	// Update
+	update := map[string]any{
+		"name":    "test-trunk",
+		"host":    "10.0.0.2",
+		"port":    5090,
+		"context": "from-trunk",
+	}
+	w = doRequest(h.UpdateTrunk, "PUT", "/api/trunks/1", update, map[string]string{"id": "1"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: got %d, want 200. body: %s", w.Code, w.Body.String())
+	}
+
+	// Delete
+	w = doRequest(h.DeleteTrunk, "DELETE", "/api/trunks/1", nil, map[string]string{"id": "1"})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete: got %d, want 204", w.Code)
+	}
+
+	// Get after delete — 404
+	w = doRequest(h.GetTrunk, "GET", "/api/trunks/1", nil, map[string]string{"id": "1"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("get after delete: got %d, want 404", w.Code)
+	}
+}
+
+func TestAPITrunks_CreateValidation(t *testing.T) {
+	h, _ := setupAPI(t)
+
+	// Missing required fields
+	w := doRequest(h.CreateTrunk, "POST", "/api/trunks", map[string]string{"name": "t"}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("validation: got %d, want 400", w.Code)
+	}
+
+	// Invalid JSON
+	req := httptest.NewRequest("POST", "/api/trunks", bytes.NewBufferString("{bad"))
+	req.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	h.CreateTrunk(w2, req)
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("bad json: got %d, want 400", w2.Code)
+	}
+}
+
+// --- Dialplan API tests ---
+
+func TestAPIDialplan_CRUD(t *testing.T) {
+	h, _ := setupAPI(t)
+
+	// List — empty
+	w := doRequest(h.ListDialplanRules, "GET", "/api/dialplan", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: got %d, want 200", w.Code)
+	}
+	var rules []database.DialplanRule
+	json.NewDecoder(w.Body).Decode(&rules)
+	if len(rules) != 0 {
+		t.Fatalf("list: got %d rules, want 0", len(rules))
+	}
+
+	// Create
+	rule := map[string]any{
+		"context":  "from-internal",
+		"exten":    "_3XXX",
+		"priority": 1,
+		"app":      "Dial",
+		"appdata":  "PJSIP/${EXTEN}@my-trunk,30",
+	}
+	w = doRequest(h.CreateDialplanRule, "POST", "/api/dialplan", rule, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: got %d, want 201. body: %s", w.Code, w.Body.String())
+	}
+	var created database.DialplanRule
+	json.NewDecoder(w.Body).Decode(&created)
+	if created.App != "Dial" {
+		t.Errorf("create: app = %q, want %q", created.App, "Dial")
+	}
+	if created.ID == 0 {
+		t.Error("create: ID should be set")
+	}
+
+	// Get
+	w = doRequest(h.GetDialplanRule, "GET", "/api/dialplan/1", nil, map[string]string{"id": "1"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("get: got %d, want 200", w.Code)
+	}
+	var got database.DialplanRule
+	json.NewDecoder(w.Body).Decode(&got)
+	if got.Exten != "_3XXX" {
+		t.Errorf("get: exten = %q, want %q", got.Exten, "_3XXX")
+	}
+
+	// Update
+	update := map[string]any{
+		"context":  "from-internal",
+		"exten":    "_3XXX",
+		"priority": 1,
+		"app":      "NoOp",
+		"appdata":  "Updated rule",
+	}
+	w = doRequest(h.UpdateDialplanRule, "PUT", "/api/dialplan/1", update, map[string]string{"id": "1"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: got %d, want 200. body: %s", w.Code, w.Body.String())
+	}
+
+	// Verify update
+	w = doRequest(h.GetDialplanRule, "GET", "/api/dialplan/1", nil, map[string]string{"id": "1"})
+	json.NewDecoder(w.Body).Decode(&got)
+	if got.App != "NoOp" {
+		t.Errorf("after update: app = %q, want %q", got.App, "NoOp")
+	}
+
+	// Delete
+	w = doRequest(h.DeleteDialplanRule, "DELETE", "/api/dialplan/1", nil, map[string]string{"id": "1"})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete: got %d, want 204", w.Code)
+	}
+
+	// Get after delete — 404
+	w = doRequest(h.GetDialplanRule, "GET", "/api/dialplan/1", nil, map[string]string{"id": "1"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("get after delete: got %d, want 404", w.Code)
+	}
+}
+
+func TestAPIDialplan_CreateValidation(t *testing.T) {
+	h, _ := setupAPI(t)
+
+	// Missing required fields
+	w := doRequest(h.CreateDialplanRule, "POST", "/api/dialplan", map[string]string{"context": "x"}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("validation: got %d, want 400", w.Code)
+	}
+}
+
+func TestAPIDialplan_DefaultPriority(t *testing.T) {
+	h, _ := setupAPI(t)
+
+	rule := map[string]any{
+		"context": "from-internal",
+		"exten":   "1001",
+		"app":     "NoOp",
+	}
+	w := doRequest(h.CreateDialplanRule, "POST", "/api/dialplan", rule, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: got %d, want 201", w.Code)
+	}
+	var created database.DialplanRule
+	json.NewDecoder(w.Body).Decode(&created)
+	if created.Priority != 1 {
+		t.Errorf("priority = %d, want 1", created.Priority)
+	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/server/internal/handlers/api_test.go
+++ b/server/internal/handlers/api_test.go
@@ -67,11 +67,13 @@ func TestAPITrunks_CRUD(t *testing.T) {
 
 	// Create
 	trunk := map[string]any{
-		"name":    "test-trunk",
-		"host":    "10.0.0.1",
-		"port":    5080,
-		"context": "from-trunk",
-		"codecs":  "ulaw,alaw",
+		"name":      "test-trunk",
+		"host":      "10.0.0.1",
+		"port":      5080,
+		"context":   "from-trunk",
+		"codecs":    "ulaw,alaw",
+		"auth_user": "myuser",
+		"auth_pass": "secret123",
 	}
 	w = doRequest(h.CreateTrunk, "POST", "/api/trunks", trunk, nil)
 	if w.Code != http.StatusCreated {
@@ -85,6 +87,9 @@ func TestAPITrunks_CRUD(t *testing.T) {
 	if created.ID == 0 {
 		t.Error("create: ID should be set")
 	}
+	if created.AuthPass != "" {
+		t.Error("create: auth_pass should not be returned in response")
+	}
 
 	// Get
 	w = doRequest(h.GetTrunk, "GET", "/api/trunks/1", nil, map[string]string{"id": "1"})
@@ -95,6 +100,9 @@ func TestAPITrunks_CRUD(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&got)
 	if got.Host != "10.0.0.1" {
 		t.Errorf("get: host = %q, want %q", got.Host, "10.0.0.1")
+	}
+	if got.AuthPass != "" {
+		t.Error("get: auth_pass should not be returned in response")
 	}
 
 	// Update

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -59,6 +59,21 @@ func New(db *database.DB, ariClient *ari.Client, cfg *config.Config) http.Handle
 	r.HandleFunc("/dialplan/{id}", dpH.Update).Methods("PUT")
 	r.HandleFunc("/dialplan/{id}", dpH.Delete).Methods("DELETE")
 
+	// JSON API
+	apiH := handlers.NewAPIHandler(db, ariClient)
+
+	r.HandleFunc("/api/trunks", apiH.ListTrunks).Methods("GET")
+	r.HandleFunc("/api/trunks/{id}", apiH.GetTrunk).Methods("GET")
+	r.HandleFunc("/api/trunks", apiH.CreateTrunk).Methods("POST")
+	r.HandleFunc("/api/trunks/{id}", apiH.UpdateTrunk).Methods("PUT")
+	r.HandleFunc("/api/trunks/{id}", apiH.DeleteTrunk).Methods("DELETE")
+
+	r.HandleFunc("/api/dialplan", apiH.ListDialplanRules).Methods("GET")
+	r.HandleFunc("/api/dialplan/{id}", apiH.GetDialplanRule).Methods("GET")
+	r.HandleFunc("/api/dialplan", apiH.CreateDialplanRule).Methods("POST")
+	r.HandleFunc("/api/dialplan/{id}", apiH.UpdateDialplanRule).Methods("PUT")
+	r.HandleFunc("/api/dialplan/{id}", apiH.DeleteDialplanRule).Methods("DELETE")
+
 	// API actions
 	r.PathPrefix("/api/calls/").HandlerFunc(dashH.HangupCall).Methods("DELETE")
 	r.HandleFunc("/api/asterisk/reload", dashH.ReloadPJSIP).Methods("POST")


### PR DESCRIPTION
## Summary
- Add `/api/trunks` CRUD endpoints (GET list/single, POST create, PUT update, DELETE)
- Add `/api/dialplan` CRUD endpoints (GET list/single, POST create, PUT update, DELETE)
- All endpoints accept/return JSON and notify Asterisk on writes
- Tests for full CRUD lifecycle, validation, and edge cases
- Updated README API reference with JSON API docs

## Test plan
- [ ] `curl http://localhost:8080/api/trunks` returns JSON array
- [ ] `curl -X POST /api/trunks -H "Content-Type: application/json" -d '{"name":"t","host":"1.2.3.4","context":"from-trunk"}'` creates trunk and returns 201
- [ ] `curl /api/trunks/1` returns single trunk
- [ ] `curl -X PUT /api/trunks/1 ...` updates trunk
- [ ] `curl -X DELETE /api/trunks/1` returns 204
- [ ] Same flow for `/api/dialplan`
- [ ] Missing required fields return 400 with error JSON
- [ ] Invalid ID returns 400, missing resource returns 404

Closes #8