### PR TITLE
Fix from-voiceworker context to handle REFER targets

### DIFF
--- a/asterisk/config/extensions.conf
+++ b/asterisk/config/extensions.conf
@@ -38,6 +38,9 @@ switch => Realtime/@
 
 [from-voiceworker]
 switch => Realtime/@
+; Voiceworker is a trusted internal service — allow REFER targets to resolve
+; against internal extensions (same rationale does NOT apply to from-trunk).
+include => from-internal
 
 ; Voiceworker dialplan route — auto-generated when VOICEWORKER_HOST env var is set.
 #tryinclude extensions_voiceworker.conf


### PR DESCRIPTION
## Summary
- Add `include => from-internal` to `[from-voiceworker]` context so SIP REFER (blind transfer) targets resolve against internal extensions
- Unlike `from-trunk` (untrusted, #16), `from-voiceworker` is a trusted internal service — no toll fraud risk from including `from-internal`

## Test plan
- [ ] Call via voiceworker trunk, perform blind transfer to 1003 — should succeed